### PR TITLE
Update config.env handling in CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -188,6 +188,13 @@ jobs:
           SSH_KEY: ${{ secrets.SSH_KEY }}
           SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
 
+      - name: Get changed files
+        id: changed
+        run: |
+          git fetch --depth=2 origin $GITHUB_REF
+          git diff --name-only "$GITHUB_SHA" "${{ github.event.before }}" > changed_files.txt
+          echo build/config.env >> changed_files.txt
+
       - name: Rsync to Azure VM
         run: |
           echo "$SSH_KEY" > /tmp/deploy_key
@@ -201,14 +208,14 @@ jobs:
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-          rsync -avz --delete --compare-dest=$REMOTE_COMPARE_PATH \
+          rsync -avz --files-from=changed_files.txt \
             -e "ssh -i /tmp/deploy_key" \
             ./ $SSH_USER@$SSH_HOST:/var/www/myapp
 
           ssh -i /tmp/deploy_key $SSH_USER@$SSH_HOST "
-            sudo mv /var/www/myapp/build/config.env /etc/myapp/config.env
-            sudo chown root:root /etc/myapp/config.env
-            sudo chmod 600 /etc/myapp/config.env
+            sudo cp /var/www/myapp/build/config.env /var/www/myapp/config.env
+            sudo chown $SSH_USER:$SSH_USER /var/www/myapp/config.env
+            sudo chmod 600 /var/www/myapp/config.env
             sudo systemctl restart apache2
           "
         env:
@@ -216,4 +223,3 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
           SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
-          REMOTE_COMPARE_PATH: ${{ secrets.REMOTE_COMPARE_PATH }}


### PR DESCRIPTION
## Summary
- keep generated `config.env` in `/var/www/myapp` rather than overwriting `/etc/myapp/config.env`
- ensure the deployed `config.env` is owned by the SSH user
- only rsync changed files to the server during deployment

## Testing
- `pytest -q` *(fails: OpenAIError - OPENAI_API_KEY env variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68579564f548832e90098580f9d2ee8e