### PR TITLE
Fix circular import error

### DIFF
--- a/custom_auth/models.py
+++ b/custom_auth/models.py
@@ -9,7 +9,6 @@ from local_chefs.models import PostalCode, ChefPostalCode
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.conf.locale import LANG_INFO
-from meals.models import DietaryPreference
 import uuid
 
 # Create your models here.
@@ -254,7 +253,7 @@ class HouseholdMember(models.Model):
     name = models.CharField(max_length=100)
     age = models.PositiveIntegerField(blank=True, null=True)
     dietary_preferences = models.ManyToManyField(
-        DietaryPreference,
+        'meals.DietaryPreference',
         blank=True,
         related_name='household_members'
     )

--- a/meals/models.py
+++ b/meals/models.py
@@ -48,8 +48,8 @@ STATUS_REFUNDED = 'refunded'
 
 logger = logging.getLogger(__name__)
 
-OPENAI_API_KEY = settings.OPENAI_KEY
-client = OpenAI(api_key=OPENAI_API_KEY)
+OPENAI_API_KEY = getattr(settings, 'OPENAI_KEY', None)
+client = OpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
 
 class Migration(migrations.Migration):
     operations = [


### PR DESCRIPTION
## Summary
- avoid circular import by referencing meals.DietaryPreference as a string
- safely initialize OpenAI client only when API key is provided

## Testing
- `pytest -q` *(fails: SECRET_KEY setting must not be empty)*

------
https://chatgpt.com/codex/tasks/task_e_685c0f0b1e44832e89bce403553b4a17