### PR TITLE
Add household member support to frontend

### DIFF
--- a/security_utils.py
+++ b/security_utils.py
@@ -327,7 +327,20 @@ def sanitize_registration_data(user_data: Dict[str, Any]) -> Dict[str, Any]:
             ],
             'timezone': InputSanitizer.sanitize_string(user.get('timezone', ''), 50),
             'preferred_language': InputSanitizer.sanitize_string(user.get('preferred_language', ''), 10),
-            'preferred_servings': int(user.get('preferred_servings', 1)) if str(user.get('preferred_servings', 1)).isdigit() else 1,
+            'household_member_count': int(user.get('household_member_count', 1)) if str(user.get('household_member_count', 1)).isdigit() else 1,
+            'household_members': [
+                {
+                    'name': InputSanitizer.sanitize_string(member.get('name', ''), 100),
+                    'age': int(member.get('age', 0)) if str(member.get('age', 0)).isdigit() else None,
+                    'dietary_preferences': [
+                        InputSanitizer.sanitize_string(pref, 50)
+                        for pref in member.get('dietary_preferences', [])
+                        if isinstance(pref, str)
+                    ],
+                    'notes': InputSanitizer.sanitize_string(member.get('notes', ''), 200)
+                }
+                for member in user.get('household_members', []) if isinstance(member, dict)
+            ],
             'emergency_supply_goal': int(user.get('emergency_supply_goal', 0)) if str(user.get('emergency_supply_goal', 0)).isdigit() else 0
         }
     

--- a/tests/manual_registration_test.py
+++ b/tests/manual_registration_test.py
@@ -91,7 +91,7 @@ class RegistrationTester:
                 "custom_allergies": [],
                 "timezone": "UTC",
                 "preferred_language": "en",
-                "preferred_servings": 2,
+                "household_member_count": 2,
                 "emergency_supply_goal": 7
             },
             "address": {
@@ -273,7 +273,7 @@ class RegistrationTester:
                 "custom_allergies": [],
                 "timezone": "UTC",
                 "preferred_language": "en",
-                "preferred_servings": 2,
+                "household_member_count": 2,
                 "emergency_supply_goal": 7
             },
             "address": {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,7 +57,7 @@ class TestStreamlitRegistrationIntegration:
             "UTC"  # timezone
         ]
         mock_number_input.side_effect = [
-            2,  # preferred_servings
+            2,  # household_member_count
             7   # emergency_supply_goal
         ]
         mock_form_submit.return_value = True

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -27,7 +27,7 @@ class TestRegistrationValidation:
                 "custom_allergies": [],
                 "timezone": "UTC",
                 "preferred_language": "en",
-                "preferred_servings": 2,
+                "household_member_count": 2,
                 "emergency_supply_goal": 7
             },
             "address": {
@@ -437,7 +437,7 @@ class TestActualSecurityImplementation:
                 "custom_allergies": ["Custom allergy<script>"],
                 "timezone": "UTC<script>",
                 "preferred_language": "en<script>",
-                "preferred_servings": 2,
+                "household_member_count": 2,
                 "emergency_supply_goal": 7
             },
             "address": {
@@ -496,7 +496,7 @@ class TestActualSecurityImplementation:
                 "custom_allergies": [],
                 "timezone": "UTC",
                 "preferred_language": "en",
-                "preferred_servings": 2,
+                "household_member_count": 2,
                 "emergency_supply_goal": 7
             }
         }

--- a/utils.py
+++ b/utils.py
@@ -1536,7 +1536,8 @@ def login_form():
                         st.session_state['dietary_preferences'] = response_data['dietary_preferences']
                         st.session_state['custom_dietary_preferences'] = response_data.get('custom_dietary_preferences', []) 
                         st.session_state['emergency_supply_goal'] = response_data.get('emergency_supply_goal', 0)
-                        st.session_state['preffered_servings'] = response_data.get('preffered_servings', 1)
+                        st.session_state['household_member_count'] = response_data.get('household_member_count', 1)
+                        st.session_state['household_members'] = response_data.get('household_members', [])
                         st.session_state['allergies'] = response_data['allergies']
                         st.session_state['custom_allergies'] = response_data['custom_allergies']
                         st.session_state['goal_name'] = response_data['goal_name']
@@ -1601,6 +1602,8 @@ def fetch_and_update_user_profile():
                 st.session_state['custom_dietary_preferences'] = user_data.get('custom_dietary_preferences', [])  # Updated key and default
                 st.session_state['allergies'] = user_data['allergies']
                 st.session_state['custom_allergies'] = user_data['custom_allergies']
+                st.session_state['household_member_count'] = user_data.get('household_member_count', 1)
+                st.session_state['household_members'] = user_data.get('household_members', [])
                 st.session_state['goal_name'] = user_data['goals']['goal_name'] if user_data.get('goals') else ""
                 st.session_state['goal_description'] = user_data['goals']['goal_description'] if user_data.get('goals') else ""
                 st.session_state['current_role'] = user_data.get('current_role', '')

--- a/views/6_profile.py
+++ b/views/6_profile.py
@@ -141,7 +141,8 @@ try:
             allergies_val = user_data.get('allergies', [])
             custom_allergies_val = ', '.join(user_data.get('custom_allergies', []))
             unsubscribed_from_emails_val = user_data.get('unsubscribed_from_emails', False)
-            preferred_servings_val = user_data.get('preferred_servings', 1)
+            household_member_count_val = user_data.get('household_member_count', 1)
+            household_members_val = user_data.get('household_members', [])
             emergency_supply_goal_val = user_data.get('emergency_supply_goal', st.session_state.get('emergency_supply_goal', 0))
 
             street_val = address_data.get('street', '')
@@ -254,8 +255,33 @@ try:
                 selected_allergies = st.multiselect("Allergies", all_allergies, default=[a for a in allergies_val if a in all_allergies])
                 custom_allergies_input = st.text_area("Custom Allergies (comma separated)", value=custom_allergies_val, help="Enter multiple custom allergies separated by commas. Example: Peanuts, Shellfish, Kiwi")
 
-                # Preferred Servings
-                preferred_servings_input = st.number_input("Preferred Servings", min_value=1, value=preferred_servings_val, help="How many people you typically cook for or want meals scaled to.")
+                # Household Member Count
+                household_member_count_input = st.number_input(
+                    "Household Members",
+                    min_value=1,
+                    value=household_member_count_val,
+                    help="How many people live in your household?"
+                )
+
+                household_members_input = []
+                for i in range(int(household_member_count_input)):
+                    existing = household_members_val[i] if i < len(household_members_val) else {}
+                    with st.expander(f"Household Member {i+1} (optional)"):
+                        m_name = st.text_input("Name", value=existing.get('name', ''), key=f"profile_member_name_{i}")
+                        m_age = st.number_input("Age", min_value=0, value=existing.get('age', 0) or 0, step=1, key=f"profile_member_age_{i}")
+                        m_diet = st.multiselect(
+                            "Dietary Preferences",
+                            dietary_preferences,
+                            default=existing.get('dietary_preferences', []),
+                            key=f"profile_member_diet_{i}"
+                        )
+                        m_notes = st.text_area("Notes", value=existing.get('notes', ''), key=f"profile_member_notes_{i}")
+                        household_members_input.append({
+                            'name': m_name,
+                            'age': m_age if m_age else None,
+                            'dietary_preferences': m_diet,
+                            'notes': m_notes,
+                        })
 
                 # Emergency Supply Goal
                 emergency_supply_goal_input = st.number_input(
@@ -311,7 +337,8 @@ try:
                             'timezone': selected_timezone,
                             'preferred_language': selected_language_code,
                             'unsubscribed_from_emails': (receive_emails_choice == 'No'),
-                            'preferred_servings': preferred_servings_input,
+                            'household_member_count': household_member_count_input,
+                            'household_members': household_members_input,
                             'emergency_supply_goal': emergency_supply_goal_input,
                             'address': {
                                 'street': street_input,

--- a/views/7_register.py
+++ b/views/7_register.py
@@ -58,7 +58,26 @@ try:
         selected_allergies = st.multiselect("Allergies", allergies, default=[]) 
         custom_allergies = st.text_area("Custom Allergies (comma separated)", "", help="Enter multiple custom allergies separated by commas. Example: Peanuts, Shellfish, Kiwi")
         custom_allergies_list = [a.strip() for a in custom_allergies.split(',') if a.strip()]
-        preferred_servings = st.number_input("Preferred Servings", min_value=1, value=1, help="How many people do you typically cook for or want your meals scaled to?")
+        household_member_count = st.number_input(
+            "Household Members",
+            min_value=1,
+            value=1,
+            help="How many people are in your household?"
+        )
+
+        household_members = []
+        for i in range(int(household_member_count)):
+            with st.expander(f"Household Member {i+1} (optional)"):
+                member_name = st.text_input("Name", key=f"member_name_{i}")
+                member_age = st.number_input("Age", min_value=0, value=0, step=1, key=f"member_age_{i}")
+                member_diet = st.multiselect("Dietary Preferences", dietary_preferences, default=[], key=f"member_diet_{i}")
+                member_notes = st.text_area("Notes", key=f"member_notes_{i}")
+                household_members.append({
+                    "name": member_name,
+                    "age": member_age if member_age else None,
+                    "dietary_preferences": member_diet,
+                    "notes": member_notes,
+                })
         emergency_supply_goal = st.number_input("Emergency Supply Goal (days)", min_value=0, value=0,
             help="How many days of emergency supplies do you want to keep in your pantry?")
         
@@ -166,8 +185,9 @@ try:
                     "custom_allergies": custom_allergies_list,
                     "timezone": selected_timezone,
                     "preferred_language": selected_language_code,
-                    "preferred_servings": preferred_servings,
-                    "emergency_supply_goal": emergency_supply_goal  
+                    "household_member_count": household_member_count,
+                    "household_members": household_members,
+                    "emergency_supply_goal": emergency_supply_goal
                 },
                 "address": {
                     "street": street,


### PR DESCRIPTION
## Summary
- support `household_member_count` and members list in register/profile forms
- sanitize new household member fields
- keep household count in session on login and profile refresh
- update tests for new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e073e5454832ea680825b67a84fb2