### PR TITLE
Add onboarding session tracking

### DIFF
--- a/custom_auth/admin.py
+++ b/custom_auth/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import CustomUser, Address, UserRole
+from .models import CustomUser, Address, UserRole, OnboardingSession
 
 
 
@@ -20,3 +20,4 @@ class UserRoleAdmin(admin.ModelAdmin):
 admin.site.register(CustomUser, CustomUserAdmin)
 admin.site.register(Address, AddressAdmin)
 admin.site.register(UserRole, UserRoleAdmin)
+admin.site.register(OnboardingSession)

--- a/custom_auth/migrations/0037_onboarding_session.py
+++ b/custom_auth/migrations/0037_onboarding_session.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('custom_auth', '0036_remove_customuser_preferred_servings_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OnboardingSession',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('guest_id', models.CharField(max_length=40, unique=True)),
+                ('data', models.JSONField(default=dict)),
+                ('completed', models.BooleanField(default=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+            ],
+        ),
+    ]

--- a/custom_auth/models.py
+++ b/custom_auth/models.py
@@ -279,5 +279,18 @@ class UserRole(models.Model):
 
     def __str__(self):
         return f'{self.user.username} - {self.current_role}'
+
+
+class OnboardingSession(models.Model):
+    """Track registration info collected for guest onboarding."""
+
+    guest_id = models.CharField(max_length=40, unique=True)
+    data = models.JSONField(default=dict)
+    completed = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f"OnboardingSession({self.guest_id})"
     
 

--- a/customer_dashboard/urls.py
+++ b/customer_dashboard/urls.py
@@ -51,6 +51,8 @@ urlpatterns = [
     path('api/assistant/conversation/<str:user_id>/history/', views.get_conversation_history, name='get_conversation_history'),
     path('api/assistant/new-conversation/', views.new_conversation, name='new_conversation'),
     path('api/assistant/guest-new-conversation/', views.guest_new_conversation, name='guest_new_conversation'),
+    path('api/assistant/onboarding/stream-message/', views.onboarding_stream_message, name='onboarding_stream_message'),
+    path('api/assistant/onboarding/new-conversation/', views.onboarding_new_conversation, name='onboarding_new_conversation'),
     path('api/email-assistant/process/', secure_email_integration.process_email, name='process_email')
 
 ]

--- a/meals/tool_registration.py
+++ b/meals/tool_registration.py
@@ -87,7 +87,9 @@ from .guest_tools import (
     guest_search_dishes,
     guest_search_chefs,
     guest_get_meal_plan,
-    guest_search_ingredients
+    guest_search_ingredients,
+    guest_register_user,
+    onboarding_save_progress,
 )
 
 logger = logging.getLogger(__name__)
@@ -153,6 +155,8 @@ TOOL_FUNCTION_MAP = {
     "guest_search_chefs": guest_search_chefs,
     "guest_get_meal_plan": guest_get_meal_plan,
     "guest_search_ingredients": guest_search_ingredients,
+    "guest_register_user": guest_register_user,
+    "onboarding_save_progress": onboarding_save_progress,
     "chef_service_areas": chef_service_areas
 }
 


### PR DESCRIPTION
## Summary
- create `OnboardingSession` model to persist chat-based registration data
- register the model in admin and migrations
- expand guest tools with `onboarding_save_progress`
- update `guest_register_user` to mark onboarding complete
- enhance `OnboardingAssistant` to show progress and use new tools

## Testing
- `pytest -q` *(fails: REDIS_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_6867b72b6fd0832e8f29742c50554431