### PR TITLE
Enable chat or form registration choice

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import os
 import time
 from typing_extensions import override
-from typing import Tuple, Iterator
+from typing import Tuple, Iterator, Optional, Any
 from openai import OpenAIError
 from openai import AssistantEventHandler, OpenAI, BadRequestError
 from openai.types.beta.threads.runs import ToolCall, ToolCallDelta
@@ -1273,6 +1273,82 @@ def display_chat_message(role: str, content: str):
     """
     with st.chat_message(role):
         st.markdown(content)
+
+# ============================
+# Onboarding Chat Helpers
+# ============================
+
+def start_onboarding_conversation(guest_id: Optional[str] = None) -> Optional[str]:
+    """Start or reset the onboarding chat and return the guest_id."""
+    payload = {}
+    if guest_id:
+        payload["guest_id"] = guest_id
+    try:
+        response = dj_post(
+            "/customer_dashboard/api/assistant/onboarding/new-conversation/",
+            json=payload,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            return data.get("guest_id")
+    except Exception as e:
+        logging.error(f"Error starting onboarding chat: {e}")
+    return None
+
+
+def onboarding_event_stream(message: str, guest_id: str, response_id: Optional[str] = None):
+    """Yield SSE events from the onboarding assistant."""
+    data = {"guest_id": guest_id, "message": message}
+    if response_id:
+        data["response_id"] = response_id
+
+    with dj_post(
+        "/customer_dashboard/api/assistant/onboarding/stream-message/",
+        json=data,
+        stream=True,
+    ) as response:
+        if response.status_code != 200:
+            yield {"type": "error", "message": f"HTTP {response.status_code}"}
+            return
+
+        for raw_line in response.iter_lines():
+            if not raw_line:
+                continue
+            decoded = raw_line.decode("utf-8")
+            if not decoded.startswith("data:"):
+                continue
+            payload = decoded[len("data:"):].strip()
+            try:
+                event = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            yield event
+
+
+def display_onboarding_stream(message: str, guest_id: str, response_id: Optional[str] = None):
+    """Stream onboarding assistant text and capture tool output."""
+    events = onboarding_event_stream(message, guest_id, response_id)
+    accumulated = ""
+    tool_output = None
+
+    def text_gen():
+        nonlocal accumulated, tool_output, response_id
+        for ev in events:
+            et = ev.get("type")
+            if et == "response.created" and ev.get("id"):
+                response_id = ev["id"]
+            elif et == "response.output_text.delta":
+                delta = ev.get("delta", {}).get("text", "") or ev.get("content", "")
+                if delta:
+                    accumulated += delta
+                    yield delta
+            elif et == "response.tool":
+                tool_output = ev.get("output")
+            elif et == "response.completed":
+                break
+
+    st.write_stream(text_gen())
+    return response_id, accumulated, tool_output
 # ============================
 # Utility functions
 # ============================

--- a/views/7_register.py
+++ b/views/7_register.py
@@ -9,9 +9,19 @@ import requests
 import pycountry
 import datetime
 import pytz
-from utils import (api_call_with_refresh, login_form, toggle_chef_mode, 
-                   fetch_and_update_user_profile, validate_input, parse_comma_separated_input, footer,
-                   fetch_languages, navigate_to_page)
+from utils import (
+    api_call_with_refresh,
+    login_form,
+    toggle_chef_mode,
+    fetch_and_update_user_profile,
+    validate_input,
+    parse_comma_separated_input,
+    footer,
+    fetch_languages,
+    navigate_to_page,
+    start_onboarding_conversation,
+    display_onboarding_stream,
+)
 from security_utils import (
     sanitize_registration_data, 
     validate_registration_security,
@@ -32,9 +42,72 @@ logging.basicConfig(level=logging.WARNING,
 # Initialize rate limiter (in production, use Redis or database-backed limiter)
 rate_limiter = RateLimiter(max_attempts=5, window_minutes=15)
 
+st.title("Register")
+
+if 'registration_method' not in st.session_state:
+    st.session_state.registration_method = 'chat'
+
+method_choice = st.radio(
+    "How would you like to register?",
+    ("Chat with assistant", "Traditional form"),
+    index=0 if st.session_state.registration_method == 'chat' else 1,
+)
+
+st.session_state.registration_method = (
+    'chat' if method_choice == "Chat with assistant" else 'form'
+)
+
+# ----------------------------
+# Chat-based Registration
+# ----------------------------
+
+if st.session_state.registration_method == 'chat':
+    if 'onboarding_guest_id' not in st.session_state:
+        guest = start_onboarding_conversation()
+        if guest:
+            st.session_state.onboarding_guest_id = guest
+            st.session_state.onboarding_chat_history = []
+            st.session_state.onboarding_response_id = None
+
+    if not st.session_state.get('onboarding_complete'):
+        st.write("Create an account by chatting with our onboarding assistant.")
+
+        chat_container = st.container()
+        for msg in st.session_state.get('onboarding_chat_history', []):
+            with chat_container.chat_message(msg['role']):
+                st.markdown(msg['content'])
+
+        user_msg = st.chat_input("Message")
+        if user_msg:
+            st.session_state.onboarding_chat_history.append({'role': 'user', 'content': user_msg})
+            with chat_container.chat_message('user'):
+                st.markdown(user_msg)
+            with chat_container.chat_message('assistant'):
+                resp_id, full_text, tool_out = display_onboarding_stream(
+                    user_msg,
+                    st.session_state.onboarding_guest_id,
+                    st.session_state.get('onboarding_response_id')
+                )
+                st.session_state.onboarding_response_id = resp_id
+                st.session_state.onboarding_chat_history.append({'role': 'assistant', 'content': full_text})
+                if tool_out:
+                    try:
+                        data = json.loads(tool_out) if isinstance(tool_out, str) else tool_out
+                        st.session_state['user_info'] = data
+                        st.session_state['user_id'] = data.get('user_id')
+                        st.session_state['access_token'] = data.get('access')
+                        st.session_state['refresh_token'] = data.get('refresh')
+                        st.session_state['is_logged_in'] = True
+                        st.session_state['onboarding_complete'] = True
+                        st.rerun()
+                    except Exception as e:
+                        logging.error(f"Failed to process tool output: {e}")
+        st.stop()
+
 # Content moved from register() to top level
 try:
-    st.title("Register")
+    if st.session_state.get('onboarding_complete'):
+        st.success("Account created! You can adjust your details below.")
     st.write("Create an account.")
 
     with st.form(key='registration_form'):


### PR DESCRIPTION
## Summary
- let user choose chat-based or traditional form registration
- only start onboarding chat when chat method selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868dc2a8c68832ea0705e2ee1235919