### PR TITLE
Fix Redis SSL parameter compatibility

### DIFF
--- a/utils/quotas.py
+++ b/utils/quotas.py
@@ -24,15 +24,28 @@ def get_redis_connection():
     try:
         # Parse the Redis URL and create connection with SSL verification
         # Use ssl_cert_reqs instead of ssl_check_hostname for compatibility with older Celery/Kombu
-        return redis.Redis.from_url(
-            redis_url,
-            decode_responses=True,
-            socket_keepalive=True,
-            socket_keepalive_options={},
-            health_check_interval=30,
-            retry_on_error=[redis.exceptions.ReadOnlyError, redis.exceptions.ConnectionError],
-            ssl_cert_reqs=ssl.CERT_NONE,  # Skip SSL certificate verification (compatible with older packages)
-        )
+        try:
+            return redis.Redis.from_url(
+                redis_url,
+                decode_responses=True,
+                socket_keepalive=True,
+                socket_keepalive_options={},
+                health_check_interval=30,
+                retry_on_error=[redis.exceptions.ReadOnlyError, redis.exceptions.ConnectionError],
+                ssl_cert_reqs=ssl.CERT_NONE,  # Skip SSL certificate verification (compatible with older packages)
+            )
+        except TypeError as ssl_error:
+            logger.warning(
+                f"SSL parameter not supported, trying without ssl_cert_reqs: {ssl_error}"
+            )
+            return redis.Redis.from_url(
+                redis_url,
+                decode_responses=True,
+                socket_keepalive=True,
+                socket_keepalive_options={},
+                health_check_interval=30,
+                retry_on_error=[redis.exceptions.ReadOnlyError, redis.exceptions.ConnectionError],
+            )
     except Exception as e:
         logger.error(f"Failed to create Redis connection: {str(e)}")
         return None

--- a/utils/translate_html.py
+++ b/utils/translate_html.py
@@ -26,15 +26,28 @@ def get_redis_connection():
     try:
         # Parse the Redis URL and create connection with SSL verification
         # Use ssl_cert_reqs instead of ssl_check_hostname for compatibility with older Celery/Kombu
-        return redis.Redis.from_url(
-            redis_url,
-            decode_responses=True,
-            socket_keepalive=True,
-            socket_keepalive_options={},
-            health_check_interval=30,
-            retry_on_error=[redis.exceptions.ReadOnlyError, redis.exceptions.ConnectionError],
-            ssl_cert_reqs=ssl.CERT_NONE,  # Skip SSL certificate verification (compatible with older packages)
-        )
+        try:
+            return redis.Redis.from_url(
+                redis_url,
+                decode_responses=True,
+                socket_keepalive=True,
+                socket_keepalive_options={},
+                health_check_interval=30,
+                retry_on_error=[redis.exceptions.ReadOnlyError, redis.exceptions.ConnectionError],
+                ssl_cert_reqs=ssl.CERT_NONE,  # Skip SSL certificate verification (compatible with older packages)
+            )
+        except TypeError as ssl_error:
+            logger.warning(
+                f"SSL parameter not supported, trying without ssl_cert_reqs: {ssl_error}"
+            )
+            return redis.Redis.from_url(
+                redis_url,
+                decode_responses=True,
+                socket_keepalive=True,
+                socket_keepalive_options={},
+                health_check_interval=30,
+                retry_on_error=[redis.exceptions.ReadOnlyError, redis.exceptions.ConnectionError],
+            )
     except Exception as e:
         logger.error(f"Failed to create Redis connection: {str(e)}")
         return None


### PR DESCRIPTION
## Summary
- gracefully handle older redis-py versions when establishing redis connections
- fall back to connection without `ssl_cert_reqs` if not supported

## Testing
- `pytest -q` *(fails: REDIS_URL, SECRET_KEY, OPENAI_API_KEY missing and network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68751599b6a4832e851f05eb713b2099