### PR TITLE
Aggregate shopping list ingredients and track meal names

### DIFF
--- a/meals/email_service.py
+++ b/meals/email_service.py
@@ -505,6 +505,7 @@ def generate_shopping_list(meal_plan_id):
                             "For such bundles, include the dish name in the 'notes' field for each relevant item (e.g., 'For baby puree' or 'Vegan dish').\n"
                             "Respect substitutions for non-chef meals.\n"
                             "When available, prefer structured meal_dishes (MealDish rows) over composed_dishes JSON.\n"
+                            "Return one entry per unique ingredient and unit; if multiple meals require the same ingredient with the same unit, combine their quantities and list all meal names in `meal_names`.\n"
                         )
                     },
                     {
@@ -639,7 +640,7 @@ def generate_shopping_list(meal_plan_id):
         ingredient = item.get("ingredient")
         quantity_value = item.get("quantity", "")
         unit = item.get("unit", "")
-        meal_name = item.get("meal_name", "")
+        meal_names = item.get("meal_names", [])
         notes = item.get("notes", "")
 
         # Handle numeric quantities (schema enforces float), but remain defensive

--- a/meals/instacart_service.py
+++ b/meals/instacart_service.py
@@ -427,7 +427,7 @@ def generate_instacart_link(user_id: int, meal_plan_id: int, postal_code: str = 
                 if chef_meal_names and original_count:
                     filtered_items = [
                         it for it in items
-                        if (it or {}).get('meal_name') not in chef_meal_names
+                        if not any(name in chef_meal_names for name in (it or {}).get('meal_names', []))
                     ]
                     removed_count = original_count - len(filtered_items)
                     if removed_count > 0:

--- a/meals/pantry_management_tools.py
+++ b/meals/pantry_management_tools.py
@@ -490,11 +490,11 @@ def generate_shopping_list(user_id: int, meal_plan_id: int):
                     "role": "developer",
                     "content": (
                         """
-                        Generate a shopping list in JSON format according to the defined schema, factoring in a user's preferred serving size for each meal. Follow the structure provided for the `ShoppingList` and include the required fields for each `ShoppingListItem`.
+                        Generate a shopping list in JSON format according to the defined schema, factoring in a user's preferred serving size for each meal. Return one entry per unique ingredient and unit; if multiple meals require the same ingredient with the same unit, combine their quantities and list all meal names in `meal_names`. Follow the structure provided for the `ShoppingList` and include the required fields for each `ShoppingListItem`.
 
                         - **ShoppingList**: This is the main container that holds a list of `ShoppingListItem` objects.
                         - **ShoppingListItem**: Each item in the list should have the following attributes:
-                        - **meal_name**: The name of the meal the ingredient is for.
+                        - **meal_names**: The names of the meals the ingredient is for.
                         - **ingredient**: The specific ingredient needed.
                         - **quantity**: Numeric-only amount required, adjusted for serving size. Use numbers only (e.g., 200, 1.5, 12). Do not include text or units here.
                         - **unit**: The unit of measurement for the quantity. Place all unit text here (e.g., "grams", "ml", "pieces").
@@ -516,7 +516,7 @@ def generate_shopping_list(user_id: int, meal_plan_id: int):
                         {
                         "items": [
                             {
-                            "meal_name": "Spaghetti Bolognese",
+                            "meal_names": ["Spaghetti Bolognese"],
                             "ingredient": "Spaghetti",
                             "quantity": 300,
                             "unit": "grams",
@@ -524,7 +524,7 @@ def generate_shopping_list(user_id: int, meal_plan_id: int):
                             "category": "pasta"
                             },
                             {
-                            "meal_name": "Spaghetti Bolognese",
+                            "meal_names": ["Spaghetti Bolognese"],
                             "ingredient": "Ground Beef",
                             "quantity": 750,
                             "unit": "grams",
@@ -532,7 +532,7 @@ def generate_shopping_list(user_id: int, meal_plan_id: int):
                             "category": "meat"
                             },
                             {
-                            "meal_name": "Caesar Salad",
+                            "meal_names": ["Caesar Salad"],
                             "ingredient": "Romaine Lettuce",
                             "quantity": 2,
                             "unit": "heads",
@@ -540,7 +540,7 @@ def generate_shopping_list(user_id: int, meal_plan_id: int):
                             "category": "vegetables"
                             },
                             {
-                            "meal_name": "Caesar Salad",
+                            "meal_names": ["Caesar Salad"],
                             "ingredient": "Parmesan Cheese",
                             "quantity": 75,
                             "unit": "grams",

--- a/meals/pydantic_models.py
+++ b/meals/pydantic_models.py
@@ -146,7 +146,7 @@ class PantryItemSchema(BaseModel):
         
 class ShoppingListItem(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    meal_name: str
+    meal_names: List[str]
     ingredient: str
     quantity: float
     unit: str

--- a/meals/tests/test_shopping_list_schema.py
+++ b/meals/tests/test_shopping_list_schema.py
@@ -1,0 +1,18 @@
+from meals.pydantic_models import ShoppingList
+
+
+def test_shopping_list_schema_meal_names():
+    data = {
+        "items": [
+            {
+                "meal_names": ["Meal A", "Meal B"],
+                "ingredient": "Tomato",
+                "quantity": 3,
+                "unit": "pieces",
+                "notes": None,
+                "category": "vegetables",
+            }
+        ]
+    }
+    result = ShoppingList.model_validate(data)
+    assert result.items[0].meal_names == ["Meal A", "Meal B"]


### PR DESCRIPTION
## Summary
- support tracking all meals per ingredient by introducing `meal_names` in shopping list schema
- guide shopping list generation to deduplicate ingredients and capture meal names
- adjust Instacart and email services for new `meal_names` field and add schema test

## Testing
- `REDIS_URL=redis://localhost:6379/0 CELERY_BROKER_URL=redis://localhost:6379/0 SECRET_KEY=test OPENAI_API_KEY=dummy pytest meals/tests/test_shopping_list_schema.py -q` *(fails: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): Max retries exceeded with url: /encodings/o200k_base.tiktoken (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*


------
https://chatgpt.com/codex/tasks/task_e_68ada56623e8832e8b170620bb6b29e5