### PR TITLE
Enhance public chef APIs and relocate waitlist handlers

### DIFF
--- a/chefs/api/waitlist.py
+++ b/chefs/api/waitlist.py
@@ -1,0 +1,76 @@
+from django.utils import timezone
+from django.db.models import F
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+
+from chefs.models import Chef, ChefWaitlistConfig, ChefWaitlistSubscription
+from meals.models import ChefMealEvent, STATUS_OPEN, STATUS_SCHEDULED
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def waitlist_config(request):
+    """Return whether the chef waitlist feature is enabled."""
+    cfg = ChefWaitlistConfig.get_config()
+    enabled = True if cfg is None else bool(getattr(cfg, 'enabled', True))
+    return Response({'enabled': enabled})
+
+
+def _count_upcoming_events(chef_id):
+    now = timezone.now()
+    return ChefMealEvent.objects.filter(
+        chef_id=chef_id,
+        status__in=[STATUS_SCHEDULED, STATUS_OPEN],
+        order_cutoff_time__gt=now,
+        orders_count__lt=F('max_orders')
+    ).count()
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def waitlist_status(request, chef_id):
+    chef = get_object_or_404(Chef, id=chef_id)
+
+    enabled = True
+    upcoming = _count_upcoming_events(chef.id)
+
+    subscribed = False
+    can_subscribe = False
+    if getattr(request, 'user', None) and request.user.is_authenticated:
+        subscribed = ChefWaitlistSubscription.objects.filter(user=request.user, chef=chef, active=True).exists()
+        can_subscribe = enabled and not subscribed and (chef.is_on_break or upcoming == 0)
+
+    return Response({
+        'enabled': enabled,
+        'subscribed': subscribed,
+        'can_subscribe': can_subscribe,
+        'chef_is_on_break': chef.is_on_break,
+        'upcoming_events_count': upcoming,
+    })
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def waitlist_subscribe(request, chef_id):
+    chef = get_object_or_404(Chef, id=chef_id)
+
+    ChefWaitlistSubscription.objects.get_or_create(
+        user=request.user,
+        chef=chef,
+        active=True,
+        defaults={},
+    )
+    return Response({'status': 'ok', 'subscribed': True})
+
+
+@api_view(['DELETE'])
+@permission_classes([IsAuthenticated])
+def waitlist_unsubscribe(request, chef_id):
+    chef = get_object_or_404(Chef, id=chef_id)
+    updated = ChefWaitlistSubscription.objects.filter(user=request.user, chef=chef, active=True).update(active=False)
+    if updated == 0:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+    return Response(status=status.HTTP_204_NO_CONTENT)

--- a/chefs/serializers.py
+++ b/chefs/serializers.py
@@ -82,7 +82,7 @@ class UserPublicSerializer(serializers.ModelSerializer):
 class ChefPublicSerializer(serializers.ModelSerializer):
     user = UserPublicSerializer(read_only=True)
     serving_postalcodes = PostalCodePublicSerializer(many=True, read_only=True)
-    photos = ChefPhotoSerializer(many=True, read_only=True)
+    photos = serializers.SerializerMethodField()
     profile_pic_url = serializers.SerializerMethodField()
     banner_url = serializers.SerializerMethodField()
 
@@ -114,6 +114,14 @@ class ChefPublicSerializer(serializers.ModelSerializer):
             url = default.image.url
             return request.build_absolute_uri(url) if request is not None else url
         return None
+
+    def get_photos(self, obj):
+        """Return only public photos, prioritizing featured items."""
+        public_photos = getattr(obj, 'public_photos', None)
+        if public_photos is None:
+            public_photos = obj.photos.filter(is_public=True)
+        serializer = ChefPhotoSerializer(public_photos[:6], many=True, context=self.context)
+        return serializer.data
 
     
 

--- a/chefs/tests.py
+++ b/chefs/tests.py
@@ -1,3 +1,106 @@
-from django.test import TestCase
+import tempfile
+from io import BytesIO
 
-# Create your tests here.
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APIClient
+from PIL import Image
+
+from custom_auth.models import CustomUser, UserRole
+from chefs.models import Chef, ChefPhoto, ChefWaitlistSubscription
+from local_chefs.models import PostalCode, ChefPostalCode
+
+
+@override_settings(MEDIA_ROOT=tempfile.gettempdir())
+class PublicChefProfileApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = CustomUser.objects.create_user(username='chefuser', password='password', email='chef@example.com')
+        UserRole.objects.create(user=self.user, is_chef=True)
+        self.chef = Chef.objects.create(user=self.user, is_verified=True, background_checked=True, insured=True)
+
+        self.postal = PostalCode.objects.create(code='10001', display_code='10001', country='US')
+        ChefPostalCode.objects.create(chef=self.chef, postal_code=self.postal)
+
+        self.public_photo = ChefPhoto.objects.create(
+            chef=self.chef,
+            image=self._image_file('public.jpg'),
+            is_public=True,
+            is_featured=True,
+        )
+        self.private_photo = ChefPhoto.objects.create(
+            chef=self.chef,
+            image=self._image_file('private.jpg'),
+            is_public=False,
+        )
+
+    def _image_file(self, name):
+        file_obj = BytesIO()
+        Image.new('RGB', (1, 1)).save(file_obj, format='JPEG')
+        file_obj.seek(0)
+        return SimpleUploadedFile(name, file_obj.read(), content_type='image/jpeg')
+
+    def test_public_profile_returns_public_photos_and_verification_flags(self):
+        url = reverse('chefs:chef_public', args=[self.chef.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['id'], self.chef.id)
+        self.assertTrue(response.data['is_verified'])
+        self.assertTrue(response.data['background_checked'])
+        self.assertTrue(response.data['insured'])
+        self.assertEqual(len(response.data['photos']), 1)
+        self.assertEqual(response.data['photos'][0]['id'], self.public_photo.id)
+        self.assertEqual(response.data['serving_postalcodes'][0]['postal_code'], '10001')
+
+    def test_public_directory_filters_by_serving_area_and_paginate(self):
+        other_user = CustomUser.objects.create_user(username='otherchef', password='password', email='other@example.com')
+        UserRole.objects.create(user=other_user, is_chef=True)
+        other_postal = PostalCode.objects.create(code='94110', display_code='94110', country='US')
+        other_chef = Chef.objects.create(user=other_user, is_verified=True)
+        ChefPostalCode.objects.create(chef=other_chef, postal_code=other_postal)
+
+        PostalCode.objects.create(code='V6B1A1', display_code='V6B 1A1', country='CA')
+
+        list_url = reverse('chefs:chef_public_directory')
+        response = self.client.get(list_url, {'serves_postal': '10001', 'page_size': 1})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('results', response.data)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['id'], self.chef.id)
+
+        slug_url = reverse('chefs:chef_public_by_username', kwargs={'slug': self.user.username})
+        slug_response = self.client.get(slug_url)
+        self.assertEqual(slug_response.status_code, 200)
+        self.assertEqual(slug_response.data['user']['username'], self.user.username)
+
+
+@override_settings(MEDIA_ROOT=tempfile.gettempdir())
+class WaitlistApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = CustomUser.objects.create_user(username='waiter', password='password', email='waiter@example.com')
+        self.chef_user = CustomUser.objects.create_user(username='chefwait', password='password', email='chefwait@example.com')
+        UserRole.objects.create(user=self.chef_user, is_chef=True)
+        self.chef = Chef.objects.create(user=self.chef_user, is_verified=True, is_on_break=True)
+
+    def test_waitlist_subscribe_and_unsubscribe(self):
+        status_url = reverse('chefs:waitlist_status', args=[self.chef.id])
+        self.assertEqual(self.client.get(status_url).status_code, 200)
+
+        self.client.force_authenticate(user=self.user)
+        subscribe_url = reverse('chefs:waitlist_subscribe', args=[self.chef.id])
+        subscribe_response = self.client.post(subscribe_url)
+        self.assertEqual(subscribe_response.status_code, 200)
+        self.assertTrue(ChefWaitlistSubscription.objects.filter(user=self.user, chef=self.chef, active=True).exists())
+
+        status_response = self.client.get(status_url)
+        self.assertTrue(status_response.data['subscribed'])
+
+        unsubscribe_url = reverse('chefs:waitlist_unsubscribe', args=[self.chef.id])
+        unsubscribe_response = self.client.delete(unsubscribe_url)
+        self.assertEqual(unsubscribe_response.status_code, 204)
+        self.assertFalse(ChefWaitlistSubscription.objects.filter(user=self.user, chef=self.chef, active=True).exists())
+

--- a/chefs/urls.py
+++ b/chefs/urls.py
@@ -1,4 +1,6 @@
-from django.urls import path 
+from django.urls import path
+
+from chefs.api import waitlist as waitlist_api
 from . import views
 
 
@@ -7,17 +9,17 @@ app_name = 'chefs'
 urlpatterns = [
     # Public API
     path('api/public/<int:chef_id>/', views.chef_public, name='chef_public'),
-    path('api/public/by-username/<str:username>/', views.chef_public_by_username, name='chef_public_by_username'),
+    path('api/public/by-username/<slug:slug>/', views.chef_public_by_username, name='chef_public_by_username'),
     path('api/lookup/by-username/<str:username>/', views.chef_lookup_by_username, name='chef_lookup_by_username'),
     path('api/public/', views.chef_public_directory, name='chef_public_directory'),
     path('api/public/<int:chef_id>/serves-my-area/', views.chef_serves_my_area, name='chef_serves_my_area'),
     path('api/public/<int:chef_id>/stripe-status/', views.chef_stripe_status, name='chef_stripe_status'),
     
     # Waitlist API
-    path('api/waitlist/config/', views.waitlist_config, name='waitlist_config'),
-    path('api/public/<int:chef_id>/waitlist/status/', views.waitlist_status, name='waitlist_status'),
-    path('api/public/<int:chef_id>/waitlist/subscribe', views.waitlist_subscribe, name='waitlist_subscribe'),
-    path('api/public/<int:chef_id>/waitlist/unsubscribe', views.waitlist_unsubscribe, name='waitlist_unsubscribe'),
+    path('api/waitlist/config/', waitlist_api.waitlist_config, name='waitlist_config'),
+    path('api/public/<int:chef_id>/waitlist/status/', waitlist_api.waitlist_status, name='waitlist_status'),
+    path('api/public/<int:chef_id>/waitlist/subscribe', waitlist_api.waitlist_subscribe, name='waitlist_subscribe'),
+    path('api/public/<int:chef_id>/waitlist/unsubscribe', waitlist_api.waitlist_unsubscribe, name='waitlist_unsubscribe'),
     
     # Gallery API - Public endpoints for chef photo galleries
     path('api/<str:username>/photos/', views.chef_gallery_photos, name='chef_gallery_photos'),

--- a/chefs/views.py
+++ b/chefs/views.py
@@ -18,9 +18,9 @@ from .serializers import (
     ChefPublicSerializer, ChefMeUpdateSerializer, ChefPhotoSerializer,
     GalleryPhotoSerializer, GalleryStatsSerializer
 )
-from .models import ChefWaitlistConfig, ChefWaitlistSubscription, ChefAvailabilityState
+from .models import ChefAvailabilityState
 from django.utils import timezone
-from django.db.models import F, Q
+from django.db.models import F, Prefetch, Q
 from meals.models import (
     ChefMealEvent, ChefMealOrder, PaymentLog,
     STATUS_SCHEDULED, STATUS_OPEN, STATUS_CANCELLED, STATUS_COMPLETED,
@@ -652,10 +652,22 @@ def me_set_break(request):
     })
 
 
+PUBLIC_PHOTO_PREFETCH = Prefetch(
+    'photos',
+    queryset=ChefPhoto.objects.filter(is_public=True).order_by('-is_featured', '-created_at'),
+    to_attr='public_photos',
+)
+
+
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def chef_public(request, chef_id):
-    chef = get_object_or_404(Chef, id=chef_id)
+    chef = get_object_or_404(
+        Chef.objects.select_related('user').prefetch_related('serving_postalcodes', PUBLIC_PHOTO_PREFETCH),
+        id=chef_id,
+    )
+    if not chef.is_verified:
+        return Response({'detail': 'Chef not found'}, status=status.HTTP_404_NOT_FOUND)
     # Ensure approved – presence of Chef row generally indicates approval; optionally check UserRole
     try:
         user_role = UserRole.objects.get(user=chef.user)
@@ -669,9 +681,16 @@ def chef_public(request, chef_id):
 
 @api_view(['GET'])
 @permission_classes([AllowAny])
-def chef_public_by_username(request, username):
-    chef = Chef.objects.filter(user__username__iexact=username).first()
+def chef_public_by_username(request, slug):
+    chef = (
+        Chef.objects.select_related('user')
+        .prefetch_related('serving_postalcodes', PUBLIC_PHOTO_PREFETCH)
+        .filter(user__username__iexact=slug)
+        .first()
+    )
     if not chef:
+        return Response({'detail': 'Chef not found'}, status=status.HTTP_404_NOT_FOUND)
+    if not chef.is_verified:
         return Response({'detail': 'Chef not found'}, status=status.HTTP_404_NOT_FOUND)
     try:
         user_role = UserRole.objects.get(user=chef.user)
@@ -702,10 +721,10 @@ def chef_lookup_by_username(request, username):
 @permission_classes([AllowAny])
 def chef_public_directory(request):
     from django.db.models import Count, Q
-    queryset = Chef.objects.all()
+    queryset = Chef.objects.select_related('user').prefetch_related('serving_postalcodes', PUBLIC_PHOTO_PREFETCH)
 
     # Only approved chefs
-    queryset = queryset.filter(user__userrole__is_chef=True)
+    queryset = queryset.filter(user__userrole__is_chef=True, is_verified=True)
 
     q = request.query_params.get('q')
     serves_postal = request.query_params.get('serves_postal')
@@ -740,6 +759,7 @@ def chef_public_directory(request):
     # Pagination
     from rest_framework.pagination import PageNumberPagination
     paginator = PageNumberPagination()
+    paginator.page_size = 12
     page_size = request.query_params.get('page_size')
     if page_size:
         try:
@@ -781,87 +801,6 @@ def chef_serves_my_area(request, chef_id):
         'user_postal_code': address.display_postalcode or address.input_postalcode,
         'user_country': address.country.code if hasattr(address.country, 'code') else str(address.country)
     })
-
-
-# =========================
-# Waitlist API Endpoints
-# =========================
-
-@api_view(['GET'])
-@permission_classes([AllowAny])
-def waitlist_config(request):
-    # Simplified: treat waitlist as enabled by default
-    cfg = ChefWaitlistConfig.get_config()
-    enabled = True if cfg is None else bool(getattr(cfg, 'enabled', True))
-    return Response({'enabled': enabled})
-
-
-def _count_upcoming_events(chef_id):
-    now = timezone.now()
-    return ChefMealEvent.objects.filter(
-        chef_id=chef_id,
-        status__in=[STATUS_SCHEDULED, STATUS_OPEN],
-        order_cutoff_time__gt=now,
-        orders_count__lt=F('max_orders')
-    ).count()
-
-
-@api_view(['GET'])
-@permission_classes([AllowAny])
-def waitlist_status(request, chef_id):
-    try:
-        chef = Chef.objects.get(id=chef_id)
-    except Chef.DoesNotExist:
-        return Response({'detail': 'Chef not found'}, status=status.HTTP_404_NOT_FOUND)
-
-    # Simplified: waitlist is enabled by default
-    enabled = True
-    upcoming = _count_upcoming_events(chef.id)
-
-    subscribed = False
-    can_subscribe = False
-    if getattr(request, 'user', None) and request.user.is_authenticated:
-        subscribed = ChefWaitlistSubscription.objects.filter(user=request.user, chef=chef, active=True).exists()
-        # Allow subscribing if chef is on break or has no upcoming orderable events
-        can_subscribe = enabled and not subscribed and (chef.is_on_break or upcoming == 0)
-
-    return Response({
-        'enabled': enabled,
-        'subscribed': subscribed,
-        'can_subscribe': can_subscribe,
-        'chef_is_on_break': chef.is_on_break,
-        'upcoming_events_count': upcoming,
-    })
-
-
-@api_view(['POST'])
-@permission_classes([IsAuthenticated])
-def waitlist_subscribe(request, chef_id):
-    try:
-        chef = Chef.objects.get(id=chef_id)
-    except Chef.DoesNotExist:
-        return Response({'detail': 'Chef not found'}, status=status.HTTP_404_NOT_FOUND)
-
-    sub, created = ChefWaitlistSubscription.objects.get_or_create(
-        user=request.user,
-        chef=chef,
-        active=True,
-        defaults={}
-    )
-    return Response({'status': 'ok', 'subscribed': True})
-
-
-@api_view(['DELETE'])
-@permission_classes([IsAuthenticated])
-def waitlist_unsubscribe(request, chef_id):
-    try:
-        chef = Chef.objects.get(id=chef_id)
-    except Chef.DoesNotExist:
-        return Response({'detail': 'Chef not found'}, status=status.HTTP_404_NOT_FOUND)
-    updated = ChefWaitlistSubscription.objects.filter(user=request.user, chef=chef, active=True).update(active=False)
-    if updated == 0:
-        return Response(status=status.HTTP_404_NOT_FOUND)
-    return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- move waitlist endpoints into a dedicated `chefs/api/waitlist.py` module and wire URLs accordingly
- tighten public chef profile responses to verified chefs with public photos and paginated directory filtering by service area
- add API tests covering public profile payloads, directory filtering, and waitlist subscribe/unsubscribe flows

## Testing
- ❌ `SECRET_KEY=test REDIS_URL=redis://localhost:6379/0 OPENAI_API_KEY=dummy DB_NAME=test DB_USER=postgres DB_PASSWORD=postgres DB_HOST=localhost DB_PORT=5432 python manage.py test chefs` (fails: PostgreSQL server unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691effae12c0832eb11e6a771af2f5b5)