### PR TITLE
Gate legacy meal plan surfaces behind feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ sautai serves multiple user types with tailored experiences:
 - **Chef Verification**: Oversee the approval process for local chefs and verify credentials
 - **Platform Management**: Manage the overall platform operations and community standards
 
+## Legacy meal-plan feature flag
+
+The legacy meal-planning stack (including `/meal-plans` links, Instacart helpers, and the old Streamlit dashboard) is controlled by the `LEGACY_MEAL_PLAN_ENABLED` setting. Production environments keep the flag off by default to avoid exposing deprecated flows; to re-enable the stack for internal testing:
+
+1. Set `LEGACY_MEAL_PLAN_ENABLED=True` in your environment (for example, in `dev.env` or the hosting provider's configuration).
+2. Restart Django so the setting propagates to the new context processor and the `/meals/api/config/` endpoint.
+3. Verify that templates render meal-plan widgets again and that the config endpoint reports `"legacy_meal_plan_enabled": true`.
+
 ## AI Assistant Prompts
 
 sautai features MJ, an AI-powered meal planning consultant. Below are the core prompt templates that define MJ's personality and capabilities:

--- a/customer_dashboard/tasks.py
+++ b/customer_dashboard/tasks.py
@@ -814,7 +814,14 @@ def process_aggregated_emails(self, session_identifier_str, use_enhanced_formatt
                     formatted_content = f'<p>{formatted_content}</p>'
                 
                 email_body_data = f"<div class='assistant-response'>{formatted_content}</div>"
-                email_body_final = f"<p>Need more help? Just reply to this email or visit your <a href='{os.getenv('STREAMLIT_URL')}/meal-plans'>sautai dashboard</a>!</p>"
+                streamlit_url = os.getenv('STREAMLIT_URL')
+                if settings.LEGACY_MEAL_PLAN_ENABLED and streamlit_url:
+                    email_body_final = (
+                        f"<p>Need more help? Just reply to this email or visit your "
+                        f"<a href='{streamlit_url}/meal-plans'>sautai dashboard</a>!</p>"
+                    )
+                else:
+                    email_body_final = "<p>Need more help? Just reply to this email.</p>"
                 css_classes = ['original-formatting']
                 
                 processing_metadata = {

--- a/customer_dashboard/views.py
+++ b/customer_dashboard/views.py
@@ -2,7 +2,7 @@
 from uuid import uuid4
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
-from django.http import JsonResponse
+from django.http import JsonResponse, Http404
 from meals.models import Order, Dish, Meal, Cart, MealPlanMeal, MealPlan, Meal
 from custom_auth.models import CustomUser, UserRole
 from django.contrib.auth.decorators import user_passes_test
@@ -78,6 +78,7 @@ from meals.guest_tool_registration import get_guest_tool_registry
 from meals.tool_registration import get_all_tools, handle_tool_call
 from meals.enhanced_email_processor import process_email_with_enhanced_formatting
 from customer_dashboard.template_router import render_email_sections
+from meals.feature_flags import legacy_meal_plan_enabled
 
 class GuestChatThrottle(UserRateThrottle):
     rate = '100/day'  
@@ -908,6 +909,9 @@ def update_week_shift(request):
 @login_required
 @user_passes_test(is_customer)
 def meal_plans(request):
+    if not legacy_meal_plan_enabled():
+        raise Http404("Legacy meal plans are disabled.")
+
     week_shift = get_current_week_shift_context(request)
 
     current_date = timezone.now()

--- a/docs/legacy_meal_plan.md
+++ b/docs/legacy_meal_plan.md
@@ -63,4 +63,5 @@ loading them from new entry points.
   detect when the legacy stack is imported.
 * When the flag is off the views are unregistered, the feature flag helper short-circuits email
   sends, and the assistant tools should also be considered unavailable because they all depend on
-  these modules.
+  these modules. The `/meals/api/config/` endpoint and template context processors expose the flag
+  value so frontends can hide `/meal-plans` widgets rather than linking to disabled routes.

--- a/hood_united/settings.py
+++ b/hood_united/settings.py
@@ -174,6 +174,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'custom_auth.context_processors.role_context_processor',
+                'meals.context_processors.legacy_meal_plan_flags',
             ],
         },
     },

--- a/meals/context_processors.py
+++ b/meals/context_processors.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+
+def legacy_meal_plan_flags(request):
+    """Expose legacy meal-plan feature flags to all templates."""
+
+    return {
+        "legacy_meal_plan_enabled": getattr(settings, "LEGACY_MEAL_PLAN_ENABLED", True),
+    }
+

--- a/meals/meal_instructions.py
+++ b/meals/meal_instructions.py
@@ -30,7 +30,7 @@ from shared.utils import generate_user_context, get_openai_client, build_age_saf
 from meals.pantry_management import get_expiring_pantry_items
 from meals.pydantic_models import BulkPrepInstructions, DailyTask
 from django.template.loader import render_to_string
-from meals.feature_flags import meal_plan_notifications_enabled
+from meals.feature_flags import meal_plan_notifications_enabled, legacy_meal_plan_enabled
 from meals.macro_info_retrieval import get_meal_macro_information
 from meals.youtube_api_search import find_youtube_cooking_videos
 import traceback
@@ -656,7 +656,11 @@ def generate_instructions(meal_plan_meal_ids, send_via_assistant: bool = False):
         grouped_instructions[meal_type].append(item)
 
 
-    streamlit_url = os.getenv("STREAMLIT_URL") + '/meal-plans'
+    streamlit_url = None
+    if legacy_meal_plan_enabled():
+        base_streamlit_url = os.getenv("STREAMLIT_URL")
+        if base_streamlit_url:
+            streamlit_url = f"{base_streamlit_url}/meal-plans"
 
 
     if send_via_assistant and instructions_list:

--- a/meals/templates/meals/bulk_prep_instructions.html
+++ b/meals/templates/meals/bulk_prep_instructions.html
@@ -193,30 +193,37 @@
         <p style="color: #555; font-size: 16px;">We hope this makes your meal prep efficient and enjoyable. If you have any questions or need further assistance, we're here to help!</p>
         <p style="color: #555; font-size: 16px;">Happy cooking!</p>
         <p style="color: #555; font-size: 16px;">Warm regards,<br>Your Team</p>
-        <p>
-            <a href="{{ streamlit_url }}/meal_plans?action=review_meal&amp;meal_plan_id={{ meal_plan_id }}">
-            Review Your Meal Plan
-            </a>
-        </p>        
+        {% if streamlit_url %}
+            <p>
+                <a href="{{ streamlit_url }}/meal_plans?action=review_meal&amp;meal_plan_id={{ meal_plan_id }}">
+                    Review Your Meal Plan
+                </a>
+            </p>
 
-        <div style="text-align: center; margin: 20px 0;">
-            <p>Be prepared for the unexpected. Generate an emergency pantry plan:</p>
-            <a href="{{ streamlit_url }}/meal_plans?action=generate_emergency_plan&approval_token={{ approval_token }}&user_id={{ user_id }}"
-               style="
-                  display: inline-block; 
-                  background-color: #ff4c4c;
-                  color: #ffffff; 
-                  padding: 10px 20px; 
-                  border-radius: 5px; 
-                  text-decoration: none;
-               ">
-              Generate Emergency Pantry Plan
-            </a>
-          </div>
-        <div class="footer">
-            <p>You are receiving this email because you opted in for bulk meal prep instructions.</p>
-            <a href="{{ streamlit_url }}/profile" class="preferences-button">Manage Your Email Preferences</a>
-        </div>
+            <div style="text-align: center; margin: 20px 0;">
+                <p>Be prepared for the unexpected. Generate an emergency pantry plan:</p>
+                <a href="{{ streamlit_url }}/meal_plans?action=generate_emergency_plan&approval_token={{ approval_token }}&user_id={{ user_id }}"
+                   style="
+                      display: inline-block;
+                      background-color: #ff4c4c;
+                      color: #ffffff;
+                      padding: 10px 20px;
+                      border-radius: 5px;
+                      text-decoration: none;
+                   ">
+                  Generate Emergency Pantry Plan
+                </a>
+              </div>
+            <div class="footer">
+                <p>You are receiving this email because you opted in for bulk meal prep instructions.</p>
+                <a href="{{ streamlit_url }}/profile" class="preferences-button">Manage Your Email Preferences</a>
+            </div>
+        {% else %}
+            <div class="footer">
+                <p>You are receiving this email because you opted in for bulk meal prep instructions.</p>
+                <p>The legacy meal plan dashboard is currently disabled.</p>
+            </div>
+        {% endif %}
     </div>
 </body>
 </html>

--- a/meals/templates/meals/daily_instructions.html
+++ b/meals/templates/meals/daily_instructions.html
@@ -99,11 +99,13 @@
                             {% endwith %}
                         </div>
                         <!-- Add the link to review this meal -->
-                        <p>
-                          <a href="{{ streamlit_url }}/meal_plans?action=review_meal&amp;meal_plan_id={{ meal.meal_plan_id }}&amp;meal_id={{ meal.meal_id }}">
-                            Review This Meal
-                          </a>
-                        </p>
+                        {% if streamlit_url %}
+                            <p>
+                              <a href="{{ streamlit_url }}/meal_plans?action=review_meal&amp;meal_plan_id={{ meal.meal_plan_id }}&amp;meal_id={{ meal.meal_id }}">
+                                Review This Meal
+                              </a>
+                            </p>
+                        {% endif %}
                       {% endfor %}
                     {% endif %}
                   {% endfor %}
@@ -112,24 +114,30 @@
                     <p>Bon appétit!</p>
                     <p>Warm regards,<br>The sautai Team</p>
 
-                    <div style="text-align: center; margin: 20px 0;">
-                      <p>Be prepared for the unexpected. Generate an emergency pantry plan:</p>
-                      <a href="{{ streamlit_url }}/meal_plans?action=generate_emergency_plan&approval_token={{ approval_token }}&user_id={{ user_id }}"
-                         style="
-                            display: inline-block; 
-                            background-color: #ff4c4c;
-                            color: #ffffff; 
-                            padding: 10px 20px; 
-                            border-radius: 5px; 
-                            text-decoration: none;
-                         ">
-                        Generate Emergency Pantry Plan
-                      </a>
-                    </div>
+                    {% if streamlit_url %}
+                        <div style="text-align: center; margin: 20px 0;">
+                          <p>Be prepared for the unexpected. Generate an emergency pantry plan:</p>
+                          <a href="{{ streamlit_url }}/meal_plans?action=generate_emergency_plan&approval_token={{ approval_token }}&user_id={{ user_id }}"
+                             style="
+                                display: inline-block;
+                                background-color: #ff4c4c;
+                                color: #ffffff;
+                                padding: 10px 20px;
+                                border-radius: 5px;
+                                text-decoration: none;
+                             ">
+                            Generate Emergency Pantry Plan
+                          </a>
+                        </div>
+                    {% endif %}
                 
                     <div class="footer">
                         <p>You are receiving this email because you opted in for cooking instructions emails.</p>
-                        <p><a href="{{ profile_url }}">Manage Your Email Preferences</a></p>
+                        {% if profile_url %}
+                            <p><a href="{{ profile_url }}">Manage Your Email Preferences</a></p>
+                        {% else %}
+                            <p>The legacy meal plan dashboard is currently disabled.</p>
+                        {% endif %}
                     </div>
                     <p style="color: #777; font-size: 12px; margin-top: 20px;">
                       <strong>Disclaimer:</strong> sautai uses generative AI for meal planning, 

--- a/meals/urls.py
+++ b/meals/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     # Existing URLs
     path('embeddings/', views.embeddings_list, name='meal_list'),
     path('approve_meal_plan/', views.meal_plan_approval, name='approve_meal_plan'),
+    path('api/config/', views.api_meals_config, name='api_meals_config'),
     
     # Keep the template URLs for admin and similar purposes, but they might not be used by Streamlit
     path('chef/meal_events/', views.chef_meal_dashboard, name='chef_meal_dashboard'),

--- a/meals/views.py
+++ b/meals/views.py
@@ -73,11 +73,20 @@ import pytz
 from django.views.decorators.csrf import csrf_exempt
 from zoneinfo import ZoneInfo
 from django.http import HttpResponseForbidden
+from meals.feature_flags import legacy_meal_plan_enabled, require_legacy_meal_plan_enabled
 
 
 LEGACY_MEAL_PLAN = True
 
 logger = logging.getLogger(__name__)
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def api_meals_config(request):
+    """Expose meal-related feature flags for frontend consumers."""
+
+    return Response({"legacy_meal_plan_enabled": legacy_meal_plan_enabled()})
 
 
 class EventStreamRenderer(renderers.BaseRenderer):
@@ -576,6 +585,7 @@ def submit_meal_plan_updates(request):
 
 
 @login_required
+@require_legacy_meal_plan_enabled
 def meal_plan_approval(request):
     # Step 1: Retrieve the current MealPlan for the user
     week_shift = max(int(request.user.week_shift), 0)

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -17,14 +17,16 @@
         <div class="hu-card-kpi">{{ metrics.users_total }}</div>
         <div class="hu-card-label">Users</div>
       </a>
-      <a class="hu-card" href="{% url 'admin:meals_mealplan_changelist' %}?is_approved__exact=1">
-        <div class="hu-card-kpi">{{ metrics.meal_plans_active }}</div>
-        <div class="hu-card-label">Active Meal Plans</div>
-      </a>
-      <a class="hu-card" href="{% url 'admin:meals_mealplan_changelist' %}?has_changes__exact=1&is_approved__exact=0">
-        <div class="hu-card-kpi">{{ metrics.approvals_pending }}</div>
-        <div class="hu-card-label">Plan Approvals</div>
-      </a>
+      {% if legacy_meal_plan_enabled %}
+        <a class="hu-card" href="{% url 'admin:meals_mealplan_changelist' %}?is_approved__exact=1">
+          <div class="hu-card-kpi">{{ metrics.meal_plans_active }}</div>
+          <div class="hu-card-label">Active Meal Plans</div>
+        </a>
+        <a class="hu-card" href="{% url 'admin:meals_mealplan_changelist' %}?has_changes__exact=1&is_approved__exact=0">
+          <div class="hu-card-kpi">{{ metrics.approvals_pending }}</div>
+          <div class="hu-card-label">Plan Approvals</div>
+        </a>
+      {% endif %}
       <a class="hu-card" href="{% url 'admin:meals_order_changelist' %}">
         <div class="hu-card-kpi">{{ metrics.orders_today }}</div>
         <div class="hu-card-label">Orders Today</div>
@@ -42,7 +44,9 @@
     <div class="hu-quick">
       <div class="hu-quick-title">Quick Actions</div>
       <div class="hu-quick-links">
-        <a href="{% url 'admin:meals_mealplan_changelist' %}?has_changes__exact=1&is_approved__exact=0" class="hu-quick-link">Review Meal Plan Changes</a>
+        {% if legacy_meal_plan_enabled %}
+          <a href="{% url 'admin:meals_mealplan_changelist' %}?has_changes__exact=1&is_approved__exact=0" class="hu-quick-link">Review Meal Plan Changes</a>
+        {% endif %}
         <a href="{% url 'admin:chefs_chefrequest_changelist' %}" class="hu-quick-link">Chef Requests</a>
         <a href="{% url 'admin:meals_systemupdate_changelist' %}" class="hu-quick-link">Send System Update</a>
         <a href="{% url 'admin:meals_order_changelist' %}" class="hu-quick-link">Orders</a>


### PR DESCRIPTION
## Summary
- expose the legacy meal plan flag through a shared context processor and new meals API config endpoint
- guard customer dashboard meal plan API and approval flow with feature flag short-circuits
- hide `/meal-plans` links in templates and documentation when the legacy stack is disabled and document how to re-enable it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230fedbde4832ebadef6893f4406b0)