### PR TITLE
fix: payment link stats use actual currency, onboarding counts dishes

### DIFF
--- a/chefs/api/payment_links.py
+++ b/chefs/api/payment_links.py
@@ -647,35 +647,47 @@ def payment_link_stats(request):
             expires_at__lt=now
         ).update(status=ChefPaymentLink.Status.EXPIRED)
         
-        # Filter amounts by chef's default currency to avoid mixing currencies
-        default_currency = chef.default_currency or 'usd'
-        currency_filter = Q(currency=default_currency)
-        
+        # Determine the dominant currency from actual payment links
+        # (fall back to chef default if no links exist)
+        from django.db.models import Count as CountAnnotation
+        currency_counts = (
+            ChefPaymentLink.objects.filter(chef=chef)
+            .values('currency')
+            .annotate(cnt=CountAnnotation('id'))
+            .order_by('-cnt')
+        )
+        if currency_counts:
+            dominant_currency = currency_counts[0]['currency']
+        else:
+            dominant_currency = chef.default_currency or 'usd'
+
+        currency_filter = Q(currency=dominant_currency)
+
         stats = ChefPaymentLink.objects.filter(chef=chef).aggregate(
             total_count=Count('id'),
             pending_count=Count('id', filter=Q(status=ChefPaymentLink.Status.PENDING)),
             paid_count=Count('id', filter=Q(status=ChefPaymentLink.Status.PAID)),
             expired_count=Count('id', filter=Q(status=ChefPaymentLink.Status.EXPIRED)),
             cancelled_count=Count('id', filter=Q(status=ChefPaymentLink.Status.CANCELLED)),
-            # Only sum amounts for payment links in the chef's default currency
+            # Sum amounts for the dominant currency to avoid mixing currencies
             total_pending_amount_cents=Sum(
-                'amount_cents', 
+                'amount_cents',
                 filter=Q(status=ChefPaymentLink.Status.PENDING) & currency_filter
             ),
             total_paid_amount_cents=Sum(
-                'paid_amount_cents', 
+                'paid_amount_cents',
                 filter=Q(status=ChefPaymentLink.Status.PAID) & currency_filter
             ),
         )
-        
+
         # Handle None values
         for key in stats:
             if stats[key] is None:
                 stats[key] = 0
-        
+
         # Include currency info so frontend can format correctly
-        stats['currency'] = default_currency.upper()
-        stats['default_currency'] = default_currency
+        stats['currency'] = dominant_currency.upper()
+        stats['default_currency'] = dominant_currency
         
         return Response(stats)
         

--- a/frontend/src/pages/ChefDashboard.jsx
+++ b/frontend/src/pages/ChefDashboard.jsx
@@ -950,11 +950,11 @@ function ChefDashboardContent(){
   const onboardingCompletionState = useMemo(() => ({
     profile: Boolean(chef?.bio && chef?.profile_pic_url),
     meeting: !meetingConfig.feature_enabled || !meetingConfig.is_required || meetingConfig.is_complete,
-    kitchen: meals.length > 0,
+    kitchen: meals.length > 0 || dishes.length > 0,
     services: serviceOfferings.length > 0,
     photos: (chef?.photos?.length || 0) >= 3,
     payouts: payouts.is_active
-  }), [chef, meals, serviceOfferings, payouts.is_active, meetingConfig])
+  }), [chef, meals, dishes, serviceOfferings, payouts.is_active, meetingConfig])
 
   const isOnboardingComplete = useMemo(() => {
     return Object.values(onboardingCompletionState).every(Boolean)


### PR DESCRIPTION
## Summary
- **Payment Links metrics**: Stats endpoint was filtering amounts by `chef.default_currency` (defaults to USD), so a ¥39,000 pending JPY link showed $0.00 pending amount. Now detects the dominant currency from actual payment links.
- **Onboarding checklist**: Kitchen completion check only looked at `meals` (meal plans, a customer concept), not chef-created `dishes`. Chefs with dishes but no meal plans incorrectly showed kitchen as incomplete (3/5 instead of 4/5).

## Test plan
- [ ] Verify payment links page shows correct pending amount in the link's actual currency
- [ ] Verify onboarding checklist correctly counts kitchen as complete when chef has dishes
- [ ] Confirm stats still work correctly for chefs with no payment links (falls back to default currency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)