### PR TITLE
feat: per-currency breakdowns in payment link stats

### DIFF
--- a/chefs/api/payment_links.py
+++ b/chefs/api/payment_links.py
@@ -647,8 +647,41 @@ def payment_link_stats(request):
             expires_at__lt=now
         ).update(status=ChefPaymentLink.Status.EXPIRED)
         
-        # Determine the dominant currency from actual payment links
-        # (fall back to chef default if no links exist)
+        # Count aggregations (not currency-dependent)
+        stats = ChefPaymentLink.objects.filter(chef=chef).aggregate(
+            total_count=Count('id'),
+            pending_count=Count('id', filter=Q(status=ChefPaymentLink.Status.PENDING)),
+            paid_count=Count('id', filter=Q(status=ChefPaymentLink.Status.PAID)),
+            expired_count=Count('id', filter=Q(status=ChefPaymentLink.Status.EXPIRED)),
+            cancelled_count=Count('id', filter=Q(status=ChefPaymentLink.Status.CANCELLED)),
+        )
+        for key in stats:
+            if stats[key] is None:
+                stats[key] = 0
+
+        # Per-currency amount breakdowns
+        pending_amounts = [
+            {'currency': row['currency'].upper(), 'amount_cents': row['amount_cents']}
+            for row in (
+                ChefPaymentLink.objects.filter(chef=chef, status=ChefPaymentLink.Status.PENDING)
+                .values('currency')
+                .annotate(amount_cents=Sum('amount_cents'))
+                .order_by('currency')
+            )
+        ]
+        paid_amounts = [
+            {'currency': row['currency'].upper(), 'amount_cents': row['amount_cents'] or 0}
+            for row in (
+                ChefPaymentLink.objects.filter(chef=chef, status=ChefPaymentLink.Status.PAID)
+                .values('currency')
+                .annotate(amount_cents=Sum('paid_amount_cents'))
+                .order_by('currency')
+            )
+        ]
+        stats['pending_amounts'] = pending_amounts
+        stats['paid_amounts'] = paid_amounts
+
+        # Legacy flat fields for backwards compatibility
         from django.db.models import Count as CountAnnotation
         currency_counts = (
             ChefPaymentLink.objects.filter(chef=chef)
@@ -656,37 +689,18 @@ def payment_link_stats(request):
             .annotate(cnt=CountAnnotation('id'))
             .order_by('-cnt')
         )
-        if currency_counts:
-            dominant_currency = currency_counts[0]['currency']
-        else:
-            dominant_currency = chef.default_currency or 'usd'
-
-        currency_filter = Q(currency=dominant_currency)
-
-        stats = ChefPaymentLink.objects.filter(chef=chef).aggregate(
-            total_count=Count('id'),
-            pending_count=Count('id', filter=Q(status=ChefPaymentLink.Status.PENDING)),
-            paid_count=Count('id', filter=Q(status=ChefPaymentLink.Status.PAID)),
-            expired_count=Count('id', filter=Q(status=ChefPaymentLink.Status.EXPIRED)),
-            cancelled_count=Count('id', filter=Q(status=ChefPaymentLink.Status.CANCELLED)),
-            # Sum amounts for the dominant currency to avoid mixing currencies
-            total_pending_amount_cents=Sum(
-                'amount_cents',
-                filter=Q(status=ChefPaymentLink.Status.PENDING) & currency_filter
-            ),
-            total_paid_amount_cents=Sum(
-                'paid_amount_cents',
-                filter=Q(status=ChefPaymentLink.Status.PAID) & currency_filter
-            ),
+        dominant_currency = (
+            currency_counts[0]['currency'] if currency_counts
+            else (chef.default_currency or 'usd')
         )
-
-        # Handle None values
-        for key in stats:
-            if stats[key] is None:
-                stats[key] = 0
-
-        # Include currency info so frontend can format correctly
-        stats['currency'] = dominant_currency.upper()
+        dominant_upper = dominant_currency.upper()
+        stats['total_pending_amount_cents'] = next(
+            (e['amount_cents'] for e in pending_amounts if e['currency'] == dominant_upper), 0
+        )
+        stats['total_paid_amount_cents'] = next(
+            (e['amount_cents'] for e in paid_amounts if e['currency'] == dominant_upper), 0
+        )
+        stats['currency'] = dominant_upper
         stats['default_currency'] = dominant_currency
         
         return Response(stats)

--- a/chefs/tests/test_payment_links.py
+++ b/chefs/tests/test_payment_links.py
@@ -908,6 +908,76 @@ class PaymentLinksAPITestCase(APITestCase):
         self.assertEqual(data['paid_count'], 1)
         self.assertEqual(data['total_pending_amount_cents'], 15000)
         self.assertEqual(data['total_paid_amount_cents'], 7500)
+        # New per-currency fields (single currency should have one entry each)
+        self.assertEqual(len(data['pending_amounts']), 1)
+        self.assertEqual(len(data['paid_amounts']), 1)
+
+    def test_get_payment_link_stats_multi_currency(self):
+        """Test stats with payment links in multiple currencies."""
+        # 2 JPY pending links
+        ChefPaymentLink.objects.create(
+            chef=self.chef, lead=self.lead, amount_cents=10000,
+            currency='jpy', description='JPY 1',
+            status=ChefPaymentLink.Status.PENDING,
+            expires_at=timezone.now() + timedelta(days=30)
+        )
+        ChefPaymentLink.objects.create(
+            chef=self.chef, lead=self.lead, amount_cents=29000,
+            currency='jpy', description='JPY 2',
+            status=ChefPaymentLink.Status.PENDING,
+            expires_at=timezone.now() + timedelta(days=30)
+        )
+        # 1 USD pending link
+        ChefPaymentLink.objects.create(
+            chef=self.chef, lead=self.lead, amount_cents=5000,
+            currency='usd', description='USD pending',
+            status=ChefPaymentLink.Status.PENDING,
+            expires_at=timezone.now() + timedelta(days=30)
+        )
+        # 1 USD paid link
+        ChefPaymentLink.objects.create(
+            chef=self.chef, lead=self.lead, amount_cents=7500,
+            currency='usd', description='USD paid',
+            status=ChefPaymentLink.Status.PAID,
+            paid_amount_cents=7500,
+            expires_at=timezone.now() + timedelta(days=30)
+        )
+
+        response = self.client.get('/chefs/api/me/payment-links/stats/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        # Counts include all currencies
+        self.assertEqual(data['total_count'], 4)
+        self.assertEqual(data['pending_count'], 3)
+        self.assertEqual(data['paid_count'], 1)
+
+        # Per-currency breakdowns
+        self.assertEqual(len(data['pending_amounts']), 2)
+        pending_by_cur = {e['currency']: e['amount_cents'] for e in data['pending_amounts']}
+        self.assertEqual(pending_by_cur['JPY'], 39000)
+        self.assertEqual(pending_by_cur['USD'], 5000)
+
+        self.assertEqual(len(data['paid_amounts']), 1)
+        self.assertEqual(data['paid_amounts'][0]['currency'], 'USD')
+        self.assertEqual(data['paid_amounts'][0]['amount_cents'], 7500)
+
+        # Legacy fields reflect dominant currency (JPY has most links)
+        self.assertEqual(data['currency'], 'JPY')
+        self.assertEqual(data['total_pending_amount_cents'], 39000)
+
+    def test_get_payment_link_stats_empty(self):
+        """Test stats when no payment links exist."""
+        response = self.client.get('/chefs/api/me/payment-links/stats/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data['total_count'], 0)
+        self.assertEqual(data['pending_count'], 0)
+        self.assertEqual(data['pending_amounts'], [])
+        self.assertEqual(data['paid_amounts'], [])
+        self.assertEqual(data['total_pending_amount_cents'], 0)
+        self.assertEqual(data['total_paid_amount_cents'], 0)
 
     def test_unauthenticated_access_denied(self):
         """Test that unauthenticated requests are denied."""

--- a/frontend/src/components/ChefPaymentLinks.jsx
+++ b/frontend/src/components/ChefPaymentLinks.jsx
@@ -252,6 +252,25 @@ export default function ChefPaymentLinks() {
   const leadClients = clients.filter(c => c.source_type === 'contact')
   const platformClients = clients.filter(c => c.source_type === 'platform')
 
+  // Format per-currency amount breakdowns for stat cards
+  const formatAmounts = (amounts, legacyCents, legacyCurrency) => {
+    if (amounts && amounts.length > 1) {
+      return (
+        <>
+          {amounts.map((entry, i) => (
+            <div key={entry.currency} style={i > 0 ? { marginTop: '4px', fontSize: '18px' } : {}}>
+              {formatAmount(entry.amount_cents, entry.currency)}
+            </div>
+          ))}
+        </>
+      )
+    }
+    if (amounts && amounts.length === 1) {
+      return formatAmount(amounts[0].amount_cents, amounts[0].currency)
+    }
+    return formatAmount(legacyCents || 0, legacyCurrency || 'USD')
+  }
+
   // Stats summary cards
   const StatCard = ({ label, value, color }) => (
     <div style={{
@@ -573,12 +592,12 @@ export default function ChefPaymentLinks() {
           <StatCard label="Paid" value={stats.paid_count || 0} color="var(--success)" />
           <StatCard
             label="Pending Amount"
-            value={formatAmount(stats.total_pending_amount_cents || 0, stats.currency || 'USD')}
+            value={formatAmounts(stats.pending_amounts, stats.total_pending_amount_cents, stats.currency)}
             color="var(--link, #007bff)"
           />
           <StatCard
             label="Collected"
-            value={formatAmount(stats.total_paid_amount_cents || 0, stats.currency || 'USD')}
+            value={formatAmounts(stats.paid_amounts, stats.total_paid_amount_cents, stats.currency)}
             color="var(--success)"
           />
         </div>


### PR DESCRIPTION
## Summary
- Stats endpoint returns `pending_amounts` and `paid_amounts` arrays grouped by currency
- Frontend stacks multiple currency amounts vertically in stat cards; single-currency chefs see no visual change
- Legacy flat fields (`total_pending_amount_cents`, `currency`, etc.) preserved for backwards compat
- Adds multi-currency and empty-state test cases

## Test plan
- [ ] Single-currency chef: stat cards look identical to before
- [ ] Multi-currency chef: pending/collected cards show stacked amounts per currency
- [ ] No payment links: cards show $0.00 (or chef's default currency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)