### PR TITLE
fix(deps): pin openai to 2.24.0 to unblock CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -246,7 +246,7 @@ numpy==2.4.4
     #   pandas
     #   pgeocode
     #   pgvector
-openai==2.32.0
+openai==2.24.0
     # via
     #   -r requirements.in
     #   litellm


### PR DESCRIPTION
## Summary

- Reverts the `openai` lockfile pin from 2.32.0 → 2.24.0 to match `litellm==1.83.10`'s exact `openai==2.24.0` requirement.
- The current main is broken: every PR (including 14 open Dependabot PRs) is failing `pip install -r requirements.txt` with `ResolutionImpossible`.
- Root cause: PR #66 bumped `openai` directly in `requirements.txt` without re-resolving the lockfile, and Dependabot doesn't catch transitive conflicts on its own.

## Why 2.24.0 specifically

Even the latest litellm (`1.83.14`) hard-pins `openai==2.24.0`, so we cannot move openai forward until upstream relaxes that pin. `openai-agents` 0.7.0 only requires `openai>=2.9.0`, so 2.24.0 satisfies it.

## Safety check

The codebase doesn't use any 2.32.0-only APIs — grep'd for `openai.auth`, `_event_handler`, `_send_queue`, `computer_action`, `namespace_tool`, `image_input_reference` (all new in 2.32) and got zero matches. We were on `openai==2.16.0` until two days ago, so 2.24.0 is still 8 minor versions forward of the last working state.

## Test plan

- [ ] CI `backend-test` job passes (currently failing on main).
- [ ] After merge, rebase the 14 open Dependabot PRs so they pick up this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)