### PR TITLE
fix(sous-chef): relax strict_mode on tools with default-valued params

### DIFF
--- a/chefs/services/sous_chef/tools/agents_tools.py
+++ b/chefs/services/sous_chef/tools/agents_tools.py
@@ -92,7 +92,7 @@ def _check_sensitive_restriction(tool_name: str) -> Optional[dict]:
 # Tool implementations wrapped with @function_tool
 # =============================================================================
 
-@function_tool
+@function_tool(strict_mode=False)
 def get_family_dietary_summary(include_member_details: bool = True) -> dict:
     """
     Get dietary preferences and restrictions for the current family.
@@ -117,7 +117,7 @@ def get_family_dietary_summary(include_member_details: bool = True) -> dict:
     return result
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def get_household_members(include_dietary_info: bool = True) -> dict:
     """
     Get information about household members.
@@ -141,7 +141,7 @@ def get_household_members(include_dietary_info: bool = True) -> dict:
     return result
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def check_recipe_compliance(
     ingredients: List[str],
     recipe_name: str = "Recipe",
@@ -179,7 +179,7 @@ def check_recipe_compliance(
     )
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def get_family_order_history(limit: int = 10) -> dict:
     """
     Get order history between chef and family.
@@ -197,7 +197,7 @@ def get_family_order_history(limit: int = 10) -> dict:
     )
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def get_upcoming_family_orders(days_ahead: int = 30) -> dict:
     """
     Get upcoming/scheduled orders for this family.
@@ -214,7 +214,7 @@ def get_upcoming_family_orders(days_ahead: int = 30) -> dict:
     )
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def add_family_note(
     summary: str,
     details: Optional[str] = None,
@@ -238,7 +238,7 @@ def add_family_note(
     )
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def search_chef_dishes(query: str, limit: int = 10) -> dict:
     """
     Search dishes in the chef's catalog.
@@ -257,7 +257,7 @@ def search_chef_dishes(query: str, limit: int = 10) -> dict:
     )
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def get_seasonal_ingredients(
     month: Optional[int] = None,
     category: str = "all",
@@ -279,7 +279,7 @@ def get_seasonal_ingredients(
     )
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def get_chef_analytics(days: int = 30) -> dict:
     """
     Get analytics and performance metrics for the chef.
@@ -297,7 +297,7 @@ def get_chef_analytics(days: int = 30) -> dict:
     )
 
 
-@function_tool
+@function_tool(strict_mode=False)
 def draft_client_message(
     message_type: str,
     key_points: List[str],


### PR DESCRIPTION
## Summary
- Sous Chef chat errored out on requests like "what allergies is mj allergic to" because Groq returned **400 Bad Request** — `Tool call validation failed: parameters for tool get_family_dietary_summary did not match schema: errors: [missing properties: 'include_member_details']`.
- Root cause: the Agents SDK's `@function_tool` defaults to `strict_mode=True`, which marks every parameter as required in the JSON schema — even ones with Python defaults like `include_member_details: bool = True`. The `gpt-oss-120b` model regularly calls these tools with `{}`, tripping Groq's strict validator.
- Fix: pass `strict_mode=False` to the 10 tools in `chefs/services/sous_chef/tools/agents_tools.py` that have default-valued params. The two tools whose params are all required (`navigate_to_dashboard_tab`, `prefill_form`) keep the default strict schema.

## Production traceback
```
litellm.exceptions.BadRequestError: GroqException -
  {"error":{"message":"Tool call validation failed: ...
    parameters for tool get_family_dietary_summary did not match schema:
    errors: [missing properties: 'include_member_details']",
   "type":"invalid_request_error","code":"tool_use_failed",
   "failed_generation":"{\"name\": \"get_family_dietary_summary\", \"arguments\": {}}"}}
```
(`sautai-django-westus2`, 2026-05-26T07:05:29Z, `_send_structured_web`)

## Test plan
- [x] `pytest chefs/services/sous_chef/tests/` — 230 passed, 2 skipped
- [ ] Manual: ask Sous Chef "what allergies is <client> allergic to" with a family selected and confirm a successful response instead of the generic error fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)